### PR TITLE
feat: add link to user guide closes #8

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -46,6 +46,7 @@ module.exports = {
     menuItems: [
       { path: 'features', label: 'Features' },
       { path: 'learn-more', label: 'Learn More' },
+      { path: 'user-guide', label: 'User Guide' },
       // { path: 'pricing', label: 'Pricing' },
       // { path: 'screenshots', label: 'Screenshots' },
       // { path: 'testimonials', label: 'Testimonials' },

--- a/src/components/navmenu.js
+++ b/src/components/navmenu.js
@@ -38,6 +38,22 @@ export default function () {
         offset={-100}
       >
         {menuItems.map((value, index) => {
+          if (value.path === 'user-guide') {
+            return (
+              <li key={String(index)}>
+                <button type="button">
+                  <a
+                    href="https://github.com/graasp/graasp-insights/blob/master/docs/introduction.md"
+                    target="_blank"
+                    rel="noreferrer"
+                    style={{ color: 'inherit' }}
+                  >
+                    {value.label}
+                  </a>
+                </button>
+              </li>
+            );
+          }
           return (
             <li key={String(index)}>
               <button


### PR DESCRIPTION
link is in main navigation bar for visibility. screenshot:

![Screen Shot 2021-06-14 at 11 02 01 AM](https://user-images.githubusercontent.com/19311953/121867203-fa1f1580-ccff-11eb-9178-485f9f87a8b7.png)

link leads [here](https://github.com/graasp/graasp-insights/blob/master/docs/introduction.md).